### PR TITLE
Don't hold build until manual confirmation for publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,6 @@
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>central</publishingServerId>
-          <waitUntil>published</waitUntil>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
With this configuration, once deployment is pushed to Maven Central, the person doing deployment must click "publish" on the web interface to confirm the operation, after review.